### PR TITLE
Update skill references in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,18 +35,18 @@ Use skills for repeatable workflows that generate or modify code. Use CLI and SD
 
 Is this a code generation or repo-editing task?
 ├─ Yes: Create or modify a pipeline project
-│ -> Use skill: creating-bauplan-pipelines (alias: /new-pipeline)
+│ -> Use skill: bauplan-data-pipelines (alias: /data-pipeline)
 ├─ Yes: Ingest data with WAP (write, audit, publish)
-│ -> Use skill: wap-ingestion (alias: /wap)
+│ -> Use skill: quality-gated-updates (alias: /quality-gated-updates)
 └─ No: Explore, query, inspect, run, debug, publish
   -> Use CLI and SDK directly (see local references)
 
 ## Skill inventory
 
-- creating-bauplan-pipelines
+- bauplan-data-pipelines
   Use when you need to scaffold a new pipeline folder, define models, add environment declarations, and produce a runnable project layout.
 
-- wap-ingestion
+- quality-gated-updates
   Use when ingesting files from S3 into a branch with a publish step. Prefer this over ad-hoc imports for anything beyond a toy dataset.
 
 - explore-data
@@ -69,9 +69,9 @@ When emitting CLI commands or SDK code, verify syntax before final output.
 ## Canonical workflows
 
 ### A) Build and publish a pipeline (end-to-end)
-For this workflow use the `new-pipeline` skill. 
+For this workflow use the `data-pipeline` skill.
 ### B) Ingest data safely (WAP)
-For this workflow use the `wap` skill.
+For this workflow use the `quality-gated-updates` skill.
 ### C) Data exploration and investigation
 
 Prefer direct CLI:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build AI-powered data engineering workflows with the Bauplan MCP Server and Agen
 This repository provides three complementary tools for AI-assisted data engineering with Bauplan:
 
 1. **Repository-based usage (CLAUDE.md + reference documentation)** - Add Bauplan workflow guidance and CLI reference directly to your repository's `.claude/` directory so AI coding assistants automatically understand Bauplan commands, safety rules, and your team's conventions without requiring tool integrations.
-2. **Agent Skills** - Reusable skill definitions for Claude Code that provide guided workflows for common code generation tasks like creating pipelines (`/new-pipeline`) and data ingestion (`/wap`).
+2. **Agent Skills** - Reusable skill definitions for Claude Code that provide guided workflows for common code generation tasks like creating pipelines (`/data-pipeline`) and data ingestion (`/quality-gated-updates`).
 3. **MCP Server** - A Model Context Protocol server that gives AI assistants (Claude Code, Claude Desktop, Cursor) access to Bauplan lakehouse operations: querying tables, schema inspection, branch management, and running pipelines. A [video walkthrough](https://www.loom.com/share/651e2bd7ad4442928f539859a621c562) demonstrates setup and usage.
 
 The intended usage for this repo is to help with *local development* by providing AI assistants access to your Bauplan lakehouse: a blog post with some context and background is available [here](https://www.bauplanlabs.com/post/bauplans-mcp-server).
@@ -49,13 +49,13 @@ your-repository/
 │   ├── bauplan-reference/
 │   │   └── bauplan_cli.md
 │   └── skills/
-│       ├── new-pipeline/
+│       ├── data-pipeline/
 │       │   └── SKILL.md
-│       ├── wap/
+│       ├── quality-gated-updates/
 │       │   └── SKILL.md
 │       ├── explore-data/
 │       │   └── SKILL.md
-│       └── root-cause-analysis/
+│       └── root-cause-analysis-and-fix/
 │           └── SKILL.md
 ├── your-bauplan-project/
 │   ├── models.py
@@ -92,12 +92,12 @@ The `skills/` folder contains reusable skill definitions for Claude Code that pr
 
 ### Available Skills
 
-| Skill                   | Description                                                                                                                              |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| **new-pipeline**        | Create a new bauplan data pipeline project from scratch, including SQL and Python models with proper project structure                   |
-| **wap**                 | Implement the Write-Audit-Publish (WAP) pattern for safe data ingestion from S3 with quality checks before publishing to production      |
-| **explore-data**        | Structured exploration of Bauplan data lakehouse: inspect schemas, sample data, analyze table profiles, and generate exploratory queries |
-| **root-cause-analysis** | Investigate and fix data issues in your Bauplan lakehouse: identify root causes, propose fixes, and validate corrections                 |
+| Skill                           | Description                                                                                                                              |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| **data-pipeline**               | Create a new bauplan data pipeline project from scratch, including SQL and Python models with proper project structure                   |
+| **quality-gated-updates**       | Implement the Write-Audit-Publish (WAP) pattern for safe data ingestion from S3 with quality checks before publishing to production      |
+| **explore-data**                | Structured exploration of Bauplan data lakehouse: inspect schemas, sample data, analyze table profiles, and generate exploratory queries |
+| **root-cause-analysis-and-fix** | Investigate and fix data issues in your Bauplan lakehouse: identify root causes, propose fixes, and validate corrections                 |
 
 ### Using Skills
 
@@ -154,7 +154,7 @@ Et voilà! You can now start asking your AI questions about your data lakehouse 
 A `CLAUDE.md` file is provided at the repository root that instructs the model on how to best use the Bauplan MCP server and the Bauplan skills provided in the `skills/` folder.
 
 **For Claude Code users**: Claude Code automatically picks up `CLAUDE.md` files and uses them as context for every interaction. This ensures the model knows:
-- Decision tree for when to use skills (`/wap`, `/new-pipeline`, `/explore-data`, `/root-cause-analysis`) vs MCP tools vs CLI/SDK
+- Decision tree for when to use skills (`/quality-gated-updates`, `/data-pipeline`, `/explore-data`, `/root-cause-analysis-and-fix`) vs MCP tools vs CLI/SDK
 - How to retrieve detailed instructions via `get_instructions`
 - How to verify SDK/CLI syntax
 - Canonical workflows for common tasks
@@ -182,12 +182,12 @@ The Beta release covers the local development use case. Authentication to your B
 
 The server supports the following CLI options, mostly useful for specifying alternative transport options:
 
-| Option | Default | Description | Used With |
-| --- | --- | --- | --- |
-| `--transport` | `stdio` | Transport protocol: `stdio`, `sse`, or `streamable-http` | All commands |
-| `--host` | `127.0.0.1` | Host to bind to (localhost by default) | `sse`, `streamable-http` only |
-| `--port` | `8000` | Port to bind to | `sse`, `streamable-http` only |
-| `--profile` | `None` | Bauplan profile to use | All commands |
+| Option        | Default     | Description                                              | Used With                     |
+|---------------|-------------|----------------------------------------------------------|-------------------------------|
+| `--transport` | `stdio`     | Transport protocol: `stdio`, `sse`, or `streamable-http` | All commands                  |
+| `--host`      | `127.0.0.1` | Host to bind to (localhost by default)                   | `sse`, `streamable-http` only |
+| `--port`      | `8000`      | Port to bind to                                          | `sse`, `streamable-http` only |
+| `--profile`   | `None`      | Bauplan profile to use                                   | All commands                  |
 
 **Note:** The `--host` and `--port` options are ignored when using `stdio` transport since it communicates through stdin/stdout.
 
@@ -315,10 +315,6 @@ If you have specific features you would like to see, please get in touch with us
 #### Instructions and Guidance
 
 - **`get_instructions`**: Get detailed instructions for specific Bauplan use cases (pipeline, data, repair, wap, test, sdk)
-
-Yes. Here is a **more concrete, procedural rewrite** of that section, aligned with what you actually ship today (`.claude/`, `bauplan-reference`, `CLAUDE.md`, skills). This tells users exactly what to do, not just that it exists.
-
-This should **replace** the lighter “Repository-based usage” section I wrote earlier.
 
 ---
 

--- a/skills/root-cause-analysis-and-fix/SKILL.md
+++ b/skills/root-cause-analysis-and-fix/SKILL.md
@@ -256,9 +256,3 @@ You must produce:
 	5.	Either:
 	•	a successful rerun on the debug branch, or
 	•	a single, concrete external blocker stated plainly
-
-
-If you want next, I can:
-	•	Strip this down into a “compact agent version”.
-	•	Add a strict decision tree that prevents Claude from touching code prematurely.
-	•	Align this 1:1 with how you want to document Bauplan + Claude workflows publicly.


### PR DESCRIPTION
## Summary

Update documentation to reflect skill name and folder reorganization:
- Update README.md to reference new skill folder names
- Update CLAUDE.md to use correct skill names in decision tree
- Remove orphaned chat-remnant text from README.md

## Changes

### README.md
- Updated skill table with correct folder names: `data-pipeline`, `quality-gated-updates`, `root-cause-analysis-and-fix`
- Updated repository structure example with new skill paths
- Updated decision tree references with new skill aliases
- Removed orphaned conversational text about "more concrete rewrite"

### CLAUDE.md
- Updated skill inventory with correct names: `bauplan-data-pipelines`, `quality-gated-updates`
- Updated decision tree to reference new skill names
- Updated canonical workflow section with correct skill references

## Test Plan

- [x] Verify README.md skill table displays correct names
- [x] Verify CLAUDE.md decision tree uses correct skill names
- [x] Verify no orphaned/incomplete text remains
- [x] Confirm skill folder structure matches documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)