### PR TITLE
feat(auth): add stateless oauth for remote mcp clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ The Beta release covers the local development use case. Authentication to your B
 
 * if you do not specify a Bauplan profile as a flag, the default one on the machine running the server will be used at every interaction with the lakehouse.
 * if you specify a profile as a flag, this profile will be used instead when instantiating a Bauplan client.
-* if you specify a header in your assistant - key=`Bauplan`, value=`your_api_key` (e.g. in Claude code `claude mcp add -H "Bauplan: <your-bauplan-api-key>" ...`) -, `your_api_key` will be used instead when instantiating a Bauplan client. This is convenient for quick tests, and opens up the possibility of hosting the catalog on a shared infrastructure, delegating to clients the Bauplan API key management.
+* if you specify a header in your assistant - either `Authorization: Bearer <your-bauplan-api-key>` or `Bauplan: <your-bauplan-api-key>` (e.g. in Claude Code `claude mcp add -H "Authorization: Bearer <your-bauplan-api-key>" ...`) -, that value will be used instead when instantiating a Bauplan client. This is convenient for quick tests, and opens up the possibility of hosting the catalog on a shared infrastructure, delegating to clients the Bauplan API key management.
+
+For example, if you are connecting to a remotely hosted MCP server that delegates Bauplan authentication to the client, you can register it in Claude Code and pass your own bearer token with:
+
+```bash
+claude mcp add -t http -H "Authorization: Bearer <your-bauplan-api-key>" mcp-bauplan https://<your-mcp-host>/mcp
+
+```
 
 ### Server CLI Options
 

--- a/mcp_bauplan/app.py
+++ b/mcp_bauplan/app.py
@@ -10,6 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
+from .auth.config import API_KEY_OAUTH_MODE, get_auth_mode, load_oauth_config
 from .tools.apply_table_creation_plan import register_apply_table_creation_plan_tool
 from .tools.cancel_job import register_cancel_job_tool
 from .tools.code_run import register_code_run_tool
@@ -108,9 +109,17 @@ def main(
     if profile:
         os.environ["BAUPLAN_PROFILE"] = profile
 
+    auth_provider = None
+    if get_auth_mode() == API_KEY_OAUTH_MODE:
+        from .auth.api_key_oauth import create_api_key_oauth_provider
+
+        auth_provider = create_api_key_oauth_provider(load_oauth_config())
+        logger.info("Enabled API-key-backed OAuth authentication")
+
     mcp = FastMCP(
         MCP_SERVER_NAME,
         instructions=INSTRUCTIONS,
+        auth=auth_provider,
         stateless_http=True,
     )
 

--- a/mcp_bauplan/auth/__init__.py
+++ b/mcp_bauplan/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication helpers for the Bauplan MCP server."""

--- a/mcp_bauplan/auth/api_key_oauth.py
+++ b/mcp_bauplan/auth/api_key_oauth.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import secrets
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from authlib.jose import JsonWebToken
+from authlib.jose.errors import JoseError
+from cryptography.fernet import Fernet, InvalidToken
+from fastmcp.server.auth.auth import AccessToken, ClientRegistrationOptions, OAuthProvider
+from fastmcp.server.auth.jwt_issuer import JWTIssuer, derive_jwt_key
+from mcp.server.auth.provider import (
+    AuthorizationCode,
+    AuthorizationParams,
+    AuthorizeError,
+    RefreshToken,
+    TokenError,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl, TypeAdapter, ValidationError
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+from .config import BAUPLAN_API_KEY_CLAIM, OAuthConfig
+
+logger = logging.getLogger(__name__)
+
+_KEY_ENTRY_PATH = "/authorize/key"
+_ENCRYPTED_API_KEY_CLAIM = "bauplan_api_key_enc"
+_TOKEN_USE_CLAIM = "token_use"
+_CLIENT_REGISTRATION_USE = "client-registration"
+
+_SIGNING_SALT = "bauplan-mcp-oauth-signing"
+_STORAGE_SALT = "bauplan-mcp-api-key-storage"
+_AUTH_CODE_TTL_SECONDS = 60
+_TXN_TTL_SECONDS = 15 * 60
+_PUBLIC_CLIENT_AUTH_METHOD = "none"
+
+_ANY_URL = TypeAdapter(AnyUrl)
+_NO_STORE_HEADERS = {
+    "Cache-Control": "no-store",
+    "Pragma": "no-cache",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+}
+_HTML_SECURITY_HEADERS = {
+    **_NO_STORE_HEADERS,
+    "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'",
+}
+
+ValidateApiKey = Callable[[str], bool | Awaitable[bool]]
+
+
+class APIKeyOAuthProvider(OAuthProvider):
+    """OAuth provider whose consent page collects a Bauplan API key.
+
+    OAuth clients, authorization codes, and tokens are stateless signed
+    containers. The Bauplan API key is encrypted into opaque JWT claims and is
+    validated only when the user authorizes or refreshes the MCP token.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: OAuthConfig,
+        validate_api_key: ValidateApiKey,
+    ) -> None:
+        super().__init__(
+            base_url=config.base_url,
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=[],
+                default_scopes=[],
+            ),
+        )
+        self._validate_api_key = validate_api_key
+        self._access_token_ttl_seconds = config.access_token_ttl_seconds
+        self._refresh_token_ttl_seconds = config.refresh_token_ttl_seconds
+        self._client_registration_ttl_seconds = config.client_registration_ttl_seconds
+        self._base_url = config.base_url
+        self._audience = f"{config.base_url.rstrip('/')}/mcp"
+        self._jwt = JsonWebToken(["HS256"])
+        self._signing_key = derive_jwt_key(
+            low_entropy_material=config.secret,
+            salt=_SIGNING_SALT,
+        )
+        self._fernet = Fernet(
+            derive_jwt_key(
+                low_entropy_material=config.secret,
+                salt=_STORAGE_SALT,
+            )
+        )
+        self._issuer = JWTIssuer(
+            issuer=config.base_url,
+            audience=self._audience,
+            signing_key=self._signing_key,
+        )
+        self._key_entry_url = f"{config.base_url.rstrip('/')}{_KEY_ENTRY_PATH}"
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        rec = self._load_container_token(client_id, expected_use=_CLIENT_REGISTRATION_USE)
+        if rec is None:
+            return None
+        return _client_from_claims(client_id, rec)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        issued_at = int(time.time())
+        client_info.token_endpoint_auth_method = _PUBLIC_CLIENT_AUTH_METHOD
+        client_info.client_secret = None
+        client_info.client_secret_expires_at = None
+        client_info.client_id_issued_at = issued_at
+        client_info.client_id = self._issue_container_token(
+            container_use=_CLIENT_REGISTRATION_USE,
+            expires_in=self._client_registration_ttl_seconds,
+            claims=_client_to_claims(client_info, issued_at),
+        )
+
+    async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
+        if client.client_id is None:
+            raise AuthorizeError("invalid_request", "client_id is required")
+        if params.resource and params.resource.rstrip("/") != self._audience:
+            raise AuthorizeError("invalid_request", "resource must match the MCP protected resource")
+
+        txn_token = self._issue_container_token(
+            container_use="auth-txn",
+            expires_in=_TXN_TTL_SECONDS,
+            claims={
+                "client_id": client.client_id,
+                "client_name": client.client_name or "MCP client",
+                "redirect_uri": str(params.redirect_uri),
+                "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
+                "state": params.state or "",
+                "code_challenge": params.code_challenge,
+                "scopes": params.scopes or [],
+                "resource": params.resource or "",
+            },
+        )
+        return f"{self._key_entry_url}?txn_id={txn_token}"
+
+    async def _render_form(self, request: Request) -> Response:
+        txn_id = request.query_params.get("txn_id", "")
+        txn = self._load_container_token(txn_id, expected_use="auth-txn")
+        if txn is None:
+            return _html_response(
+                "Authorization request expired. Please reconnect from your MCP client.", 400
+            )
+
+        client_name = html.escape(str(txn.get("client_name") or "MCP client"))
+        escaped_txn_id = html.escape(txn_id)
+        page = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bauplan MCP Authorization</title>
+</head>
+<body>
+  <h1>Authorize Bauplan MCP</h1>
+  <p><strong>{client_name}</strong> wants to connect to your Bauplan account.</p>
+  <form method="post" action="{_KEY_ENTRY_PATH}">
+    <input type="hidden" name="txn_id" value="{escaped_txn_id}">
+    <label for="api_key">Bauplan API key</label>
+    <input id="api_key" name="api_key" type="password" autocomplete="off" required autofocus>
+    <button type="submit">Authorize</button>
+  </form>
+</body>
+</html>"""
+        return HTMLResponse(page, headers=_HTML_SECURITY_HEADERS)
+
+    async def _handle_submit(self, request: Request) -> Response:
+        sec_fetch_site = request.headers.get("sec-fetch-site")
+        if sec_fetch_site not in (None, "same-origin", "none"):
+            return _html_response("Cross-site authorization blocked.", 403)
+
+        form = await request.form()
+        txn_id = str(form.get("txn_id") or "")
+        api_key = str(form.get("api_key") or "").strip()
+        txn = self._load_container_token(txn_id, expected_use="auth-txn")
+        if txn is None:
+            return _html_response(
+                "Authorization request expired. Please reconnect from your MCP client.", 400
+            )
+        if not api_key:
+            return _html_response("A Bauplan API key is required.", 400)
+
+        if not await self._call_validate_api_key(api_key):
+            logger.info("Rejected Bauplan API key during OAuth authorization")
+            return _html_response("The provided Bauplan API key could not be validated.", 401)
+
+        code = self._issue_container_token(
+            container_use="auth-code",
+            expires_in=_AUTH_CODE_TTL_SECONDS,
+            claims={
+                **txn,
+                "encrypted_api_key": self._encrypt_api_key(api_key),
+            },
+        )
+        location = construct_redirect_uri(
+            str(txn["redirect_uri"]), code=code, state=str(txn.get("state") or "")
+        )
+        return RedirectResponse(location, status_code=303, headers=_NO_STORE_HEADERS)
+
+    async def _call_validate_api_key(self, api_key: str) -> bool:
+        result = self._validate_api_key(api_key)
+        if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
+            result = await result
+        return bool(result)
+
+    async def load_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: str,
+    ) -> AuthorizationCode | None:
+        rec = self._load_container_token(authorization_code, expected_use="auth-code")
+        if rec is None or rec.get("client_id") != client.client_id:
+            return None
+
+        return AuthorizationCode(
+            code=authorization_code,
+            client_id=str(rec["client_id"]),
+            redirect_uri=rec["redirect_uri"],
+            redirect_uri_provided_explicitly=bool(rec["redirect_uri_provided_explicitly"]),
+            scopes=list(rec.get("scopes") or []),
+            expires_at=float(rec["exp"]),
+            code_challenge=str(rec["code_challenge"]),
+            resource=str(rec["resource"]) or None,
+        )
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        rec = self._load_container_token(authorization_code.code, expected_use="auth-code")
+        if rec is None or rec.get("client_id") != client.client_id:
+            raise TokenError("invalid_grant", "Authorization code not found or used.")
+
+        return await self._issue_tokens(
+            encrypted_api_key=str(rec["encrypted_api_key"]),
+            client_id=authorization_code.client_id,
+            scopes=authorization_code.scopes,
+        )
+
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        try:
+            payload = self._issuer.verify_token(refresh_token)
+        except JoseError:
+            return None
+        if payload.get(_TOKEN_USE_CLAIM) != "refresh" or payload.get("client_id") != client.client_id:
+            return None
+        if self._decrypt_api_key(payload) is None:
+            return None
+        return RefreshToken(
+            token=refresh_token,
+            client_id=str(payload["client_id"]),
+            scopes=str(payload.get("scope") or "").split(),
+            expires_at=int(payload["exp"]),
+        )
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        if not set(scopes).issubset(set(refresh_token.scopes)):
+            raise TokenError("invalid_scope", "Requested scopes exceed the original authorization.")
+
+        try:
+            old_payload = self._issuer.verify_token(refresh_token.token)
+        except JoseError as e:
+            raise TokenError("invalid_grant", "Refresh token invalid.") from e
+        api_key = self._decrypt_api_key(old_payload)
+        if api_key is None or old_payload.get("client_id") != client.client_id:
+            raise TokenError("invalid_grant", "Refresh token invalid.")
+        if not await self._call_validate_api_key(api_key):
+            raise TokenError("invalid_grant", "Bauplan API key is no longer valid.")
+
+        return await self._issue_tokens(
+            encrypted_api_key=self._encrypt_api_key(api_key),
+            client_id=client.client_id or refresh_token.client_id,
+            scopes=scopes,
+        )
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        try:
+            payload = self._issuer.verify_token(token)
+        except JoseError:
+            return None
+        if payload.get(_TOKEN_USE_CLAIM) != "access":
+            return None
+
+        api_key = self._decrypt_api_key(payload)
+        if api_key is None:
+            return None
+
+        return AccessToken(
+            token=token,
+            client_id=str(payload["client_id"]),
+            scopes=str(payload.get("scope") or "").split(),
+            expires_at=int(payload["exp"]),
+            claims={BAUPLAN_API_KEY_CLAIM: api_key},
+        )
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        return None
+
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        routes = super().get_routes(mcp_path)
+        routes.append(Route(_KEY_ENTRY_PATH, self._render_form, methods=["GET"]))
+        routes.append(Route(_KEY_ENTRY_PATH, self._handle_submit, methods=["POST"]))
+        return routes
+
+    async def _issue_tokens(self, *, encrypted_api_key: str, client_id: str, scopes: list[str]) -> OAuthToken:
+        access_token = self._issue_token(
+            client_id=client_id,
+            scopes=scopes,
+            encrypted_api_key=encrypted_api_key,
+            token_use="access",
+            expires_in=self._access_token_ttl_seconds,
+        )
+        refresh_token = self._issue_token(
+            client_id=client_id,
+            scopes=scopes,
+            encrypted_api_key=encrypted_api_key,
+            token_use="refresh",
+            expires_in=self._refresh_token_ttl_seconds,
+        )
+        return OAuthToken(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            token_type="Bearer",
+            expires_in=self._access_token_ttl_seconds,
+            scope=" ".join(scopes),
+        )
+
+    def _issue_token(
+        self,
+        *,
+        client_id: str,
+        scopes: list[str],
+        encrypted_api_key: str,
+        token_use: str,
+        expires_in: int,
+    ) -> str:
+        now = int(time.time())
+        payload = {
+            "iss": self._base_url,
+            "aud": self._audience,
+            "client_id": client_id,
+            "scope": " ".join(scopes),
+            "exp": now + expires_in,
+            "iat": now,
+            "jti": secrets.token_urlsafe(24),
+            _TOKEN_USE_CLAIM: token_use,
+            _ENCRYPTED_API_KEY_CLAIM: encrypted_api_key,
+        }
+        return self._jwt.encode({"alg": "HS256", "typ": "JWT"}, payload, self._signing_key).decode("utf-8")
+
+    def _encrypt_api_key(self, api_key: str) -> str:
+        return self._fernet.encrypt(api_key.encode("utf-8")).decode("ascii")
+
+    def _decrypt_api_key(self, payload: dict[str, Any]) -> str | None:
+        encrypted_api_key = payload.get(_ENCRYPTED_API_KEY_CLAIM)
+        if not isinstance(encrypted_api_key, str):
+            return None
+        try:
+            return self._fernet.decrypt(encrypted_api_key.encode("ascii")).decode("utf-8")
+        except (InvalidToken, UnicodeDecodeError, UnicodeEncodeError):
+            return None
+
+    def _issue_container_token(self, *, container_use: str, expires_in: int, claims: dict[str, Any]) -> str:
+        now = int(time.time())
+        payload = {
+            **claims,
+            "iss": self._base_url,
+            "aud": self._audience,
+            "exp": now + expires_in,
+            "iat": now,
+            "jti": secrets.token_urlsafe(24),
+            "container_use": container_use,
+        }
+        return self._jwt.encode({"alg": "HS256", "typ": "JWT"}, payload, self._signing_key).decode("utf-8")
+
+    def _load_container_token(self, token: str, *, expected_use: str) -> dict[str, Any] | None:
+        try:
+            payload = self._issuer.verify_token(token)
+        except JoseError:
+            return None
+        if payload.get("container_use") != expected_use:
+            return None
+        return dict(payload)
+
+
+async def validate_bauplan_api_key(api_key: str) -> bool:
+    """Validate a Bauplan API key without leaking exception details to clients."""
+    try:
+        import bauplan
+
+        await asyncio.to_thread(bauplan.Client(api_key=api_key).info)
+    except Exception:
+        return False
+    return True
+
+
+def create_api_key_oauth_provider(config: OAuthConfig) -> APIKeyOAuthProvider:
+    return APIKeyOAuthProvider(config=config, validate_api_key=validate_bauplan_api_key)
+
+
+def _html_response(content: str, status_code: int) -> HTMLResponse:
+    return HTMLResponse(content, status_code, headers=_HTML_SECURITY_HEADERS)
+
+
+def _client_to_claims(client_info: OAuthClientInformationFull, issued_at: int) -> dict[str, Any]:
+    return {
+        "client_id_issued_at": issued_at,
+        "redirect_uris": [str(uri) for uri in client_info.redirect_uris or []],
+        "grant_types": list(client_info.grant_types),
+        "response_types": list(client_info.response_types),
+        "scope": client_info.scope or "",
+        "client_name": client_info.client_name or "",
+    }
+
+
+def _client_from_claims(client_id: str, claims: dict[str, Any]) -> OAuthClientInformationFull | None:
+    try:
+        return OAuthClientInformationFull(
+            client_id=client_id,
+            client_id_issued_at=int(claims["client_id_issued_at"]),
+            client_secret=None,
+            client_secret_expires_at=None,
+            redirect_uris=[_ANY_URL.validate_python(uri) for uri in claims.get("redirect_uris") or []],
+            token_endpoint_auth_method=_PUBLIC_CLIENT_AUTH_METHOD,
+            grant_types=list(claims.get("grant_types") or ["authorization_code", "refresh_token"]),
+            response_types=list(claims.get("response_types") or ["code"]),
+            scope=str(claims.get("scope") or "") or None,
+            client_name=str(claims.get("client_name") or "") or None,
+        )
+    except (KeyError, TypeError, ValueError, ValidationError):
+        return None

--- a/mcp_bauplan/auth/config.py
+++ b/mcp_bauplan/auth/config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+AuthMode = Literal["none", "api-key-oauth"]
+
+MIN_SECRET_LENGTH = 32
+API_KEY_OAUTH_MODE: AuthMode = "api-key-oauth"
+BAUPLAN_API_KEY_CLAIM = "bauplan_api_key"
+
+
+@dataclass(frozen=True)
+class OAuthConfig:
+    base_url: str
+    secret: str
+    access_token_ttl_seconds: int = 15 * 60
+    refresh_token_ttl_seconds: int = 60 * 60 * 24 * 7
+    client_registration_ttl_seconds: int = 60 * 60 * 24 * 30
+
+
+def get_auth_mode() -> AuthMode:
+    mode = os.getenv("MCP_AUTH_MODE", "none").strip().lower()
+    if mode in ("", "none"):
+        return "none"
+    if mode == API_KEY_OAUTH_MODE:
+        return API_KEY_OAUTH_MODE
+    raise ValueError("MCP_AUTH_MODE must be either 'none' or 'api-key-oauth'")
+
+
+def load_oauth_config() -> OAuthConfig:
+    base_url = _required_env("MCP_PUBLIC_BASE_URL").rstrip("/")
+    secret = _required_env("MCP_OAUTH_SECRET")
+    if len(secret) < MIN_SECRET_LENGTH:
+        raise ValueError(f"MCP_OAUTH_SECRET must be at least {MIN_SECRET_LENGTH} characters")
+
+    return OAuthConfig(
+        base_url=base_url,
+        secret=secret,
+        access_token_ttl_seconds=_positive_int_env("MCP_OAUTH_ACCESS_TOKEN_TTL_SECONDS", 15 * 60),
+        refresh_token_ttl_seconds=_positive_int_env(
+            "MCP_OAUTH_REFRESH_TOKEN_TTL_SECONDS",
+            60 * 60 * 24 * 7,
+        ),
+        client_registration_ttl_seconds=_positive_int_env(
+            "MCP_OAUTH_CLIENT_REGISTRATION_TTL_SECONDS",
+            60 * 60 * 24 * 30,
+        ),
+    )
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise ValueError(f"{name} is required when MCP_AUTH_MODE=api-key-oauth")
+    return value.strip()
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as e:
+        raise ValueError(f"{name} must be a positive integer") from e
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return parsed

--- a/mcp_bauplan/tools/create_client.py
+++ b/mcp_bauplan/tools/create_client.py
@@ -1,43 +1,24 @@
 import logging
-import os
 
 import bauplan
-from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.dependencies import get_access_token, get_http_request
 
 logger = logging.getLogger(__name__)
 
 
-def create_bauplan_client(api_key: str | None = None) -> bauplan.Client:
-    """
-    Creates and validates a connection Bauplan.
-    Retrieves connection parameters from config, establishes a connection.
+def _extract_token(raw: str | None) -> str | None:
+    """Normalize bearer-style headers to a plain token string."""
+    if not raw:
+        return None
 
-    Returns:
-        Client: A configured Bauplan client instance
+    value = raw.strip()
+    if not value:
+        return None
 
-    Raises:
-        ConnectionError: When connection cannot be established
-    """
-    try:
-        # Establish connection to Bauplan - note that a profile variable
-        # will be used if present
-        if os.environ.get("BAUPLAN_PROFILE"):
-            logger.info("Using Bauplan profile from environment variable")
-            client = bauplan.Client(profile=os.environ["BAUPLAN_PROFILE"])
-        # if api key is passed, use it
-        elif api_key:
-            logger.info("Init Bauplan client without profile")
-            client = bauplan.Client(api_key=api_key)
-        else:
-            logger.info("Init Bauplan client without profile or api_key")
-            client = bauplan.Client()
-        logger.info("Connected to Bauplan")
-        return client
+    if value.lower().startswith("bearer "):
+        value = value[7:].strip()
 
-    except Exception as e:
-        # Handle unexpected errors
-        logger.error(f"Failed to connect to Bauplan: {e!s}", exc_info=True)
-        raise ConnectionError(f"Unable to connect to Bauplan: {e!s}") from e
+    return value or None
 
 
 def get_bauplan_client() -> bauplan.Client:
@@ -46,12 +27,33 @@ def get_bauplan_client() -> bauplan.Client:
     Extracts the API key from the HTTP request header (if present) and creates a Bauplan client.
     Falls back to default credentials in stdio transport or when no header is provided.
     """
-    api_key = None
     try:
-        request = get_http_request()
-        raw = request.headers.get("bauplan") or request.headers.get("Bauplan")
-        if raw:
-            api_key = raw[7:].strip() if raw.lower().startswith("bearer ") else raw
+        http_headers = get_http_request().headers
     except Exception:
-        pass  # stdio transport — no HTTP request available
-    return create_bauplan_client(api_key)
+        # It's not an HTTP request context
+        return bauplan.Client()
+
+    # First, check for a Bauplan-specific API key header (e.g., "Bauplan" or "bauplan")
+    api_key = _extract_token(http_headers.get("Bauplan"))
+    if api_key:
+        logger.info("Using Bauplan credentials from HTTP header")
+        return bauplan.Client(api_key=api_key)
+
+    # Check for a valid OAuth access token if available
+    try:
+        access_token = get_access_token()
+        if access_token and access_token.token:
+            logger.info("Using Bauplan credentials from validated OAuth access token")
+            return bauplan.Client(api_key=access_token.token)
+    except Exception:
+        # No valid access token available, continue to check headers
+        pass
+
+    # Finally, check the standard Authorization header for a bearer token
+    api_key = _extract_token(http_headers.get("Authorization"))
+    if api_key:
+        logger.info("Using Bauplan credentials from HTTP header")
+        return bauplan.Client(api_key=api_key)
+
+    # No valid credentials found in headers, falling back to default client
+    return bauplan.Client()

--- a/mcp_bauplan/tools/create_client.py
+++ b/mcp_bauplan/tools/create_client.py
@@ -1,57 +1,75 @@
 import logging
-import os
 
 import bauplan
-from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.dependencies import get_access_token, get_http_request
+
+from mcp_bauplan.auth.config import API_KEY_OAUTH_MODE, BAUPLAN_API_KEY_CLAIM, get_auth_mode
 
 logger = logging.getLogger(__name__)
 
 
-def create_bauplan_client(api_key: str | None = None) -> bauplan.Client:
-    """
-    Creates and validates a connection Bauplan.
-    Retrieves connection parameters from config, establishes a connection.
+def _extract_token(raw: str | None) -> str | None:
+    """Normalize bearer-style headers to a plain token string."""
+    if not raw:
+        return None
 
-    Returns:
-        Client: A configured Bauplan client instance
+    value = raw.strip()
+    if not value:
+        return None
 
-    Raises:
-        ConnectionError: When connection cannot be established
-    """
-    try:
-        # Establish connection to Bauplan - note that a profile variable
-        # will be used if present
-        if os.environ.get("BAUPLAN_PROFILE"):
-            logger.info("Using Bauplan profile from environment variable")
-            client = bauplan.Client(profile=os.environ["BAUPLAN_PROFILE"])
-        # if api key is passed, use it
-        elif api_key:
-            logger.info("Init Bauplan client without profile")
-            client = bauplan.Client(api_key=api_key)
-        else:
-            logger.info("Init Bauplan client without profile or api_key")
-            client = bauplan.Client()
-        logger.info("Connected to Bauplan")
-        return client
+    if value.lower().startswith("bearer "):
+        value = value[7:].strip()
 
-    except Exception as e:
-        # Handle unexpected errors
-        logger.error(f"Failed to connect to Bauplan: {e!s}", exc_info=True)
-        raise ConnectionError(f"Unable to connect to Bauplan: {e!s}") from e
+    return value or None
 
 
 def get_bauplan_client() -> bauplan.Client:
     """
     Dependency function for FastMCP Depends().
     Extracts the API key from the HTTP request header (if present) and creates a Bauplan client.
-    Falls back to default credentials in stdio transport or when no header is provided.
+    Falls back to default credentials outside OAuth-protected HTTP transports.
     """
-    api_key = None
     try:
-        request = get_http_request()
-        raw = request.headers.get("bauplan") or request.headers.get("Bauplan")
-        if raw:
-            api_key = raw[7:].strip() if raw.lower().startswith("bearer ") else raw
+        http_headers = get_http_request().headers
     except Exception:
-        pass  # stdio transport — no HTTP request available
-    return create_bauplan_client(api_key)
+        # It's not an HTTP request context
+        return bauplan.Client()
+
+    is_oauth_mode = get_auth_mode() == API_KEY_OAUTH_MODE
+
+    if is_oauth_mode:
+        try:
+            access_token = get_access_token()
+            api_key = getattr(access_token, "claims", {}).get(BAUPLAN_API_KEY_CLAIM) if access_token else None
+        except Exception:
+            api_key = None
+        if api_key:
+            logger.info("Using Bauplan credentials from OAuth access token")
+            return bauplan.Client(api_key=api_key)
+
+        raise RuntimeError("User is not authenticated.")
+
+    # First, check for a Bauplan-specific API key header (e.g., "Bauplan" or "bauplan")
+    api_key = _extract_token(http_headers.get("Bauplan"))
+    if api_key:
+        logger.info("Using Bauplan credentials from HTTP header")
+        return bauplan.Client(api_key=api_key)
+
+    # Check for a valid OAuth access token if available
+    try:
+        access_token = get_access_token()
+        if access_token and access_token.token:
+            logger.info("Using Bauplan credentials from OAuth access token")
+            return bauplan.Client(api_key=access_token.token)
+    except Exception:
+        # No valid access token available, continue to check headers
+        pass
+
+    # Finally, check the standard Authorization header for a bearer token
+    api_key = _extract_token(http_headers.get("Authorization"))
+    if api_key:
+        logger.info("Using Bauplan credentials from HTTP header")
+        return bauplan.Client(api_key=api_key)
+
+    # No valid credentials found in headers, falling back to default client
+    return bauplan.Client()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
   "uvicorn[standard]",
   "bauplan>=0.0.3a431",
   "pydantic~=2.12.5",
+  "authlib>=1.6.0",
+  "cryptography>=46.0.0",
 ]
 
 [project.optional-dependencies]
@@ -33,10 +35,16 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
-dev = ["watchdog[watchmedo]~=6.0.0"]
+dev = [
+  "pytest>=9.0.0",
+  "watchdog[watchmedo]~=6.0.0",
+]
 
-[tool.setuptools]
-packages = ["mcp_bauplan"]
+[tool.setuptools.packages.find]
+include = ["mcp_bauplan*"]
+
+[tool.setuptools.package-data]
+"mcp_bauplan.tools" = ["instructions/*.md"]
 
 [tool.ruff]
 fix = true
@@ -61,4 +69,3 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
-

--- a/tests/test_api_key_oauth.py
+++ b/tests/test_api_key_oauth.py
@@ -1,0 +1,293 @@
+import asyncio
+import base64
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from mcp.server.auth.provider import AuthorizationParams, AuthorizeError, RefreshToken, TokenError
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl, TypeAdapter
+
+from mcp_bauplan.auth.api_key_oauth import APIKeyOAuthProvider
+from mcp_bauplan.auth.config import BAUPLAN_API_KEY_CLAIM, OAuthConfig
+
+_ANY_URL = TypeAdapter(AnyUrl)
+
+
+def _decode_jwt_payload(token: str) -> dict:
+    payload = token.split(".")[1]
+    padded = payload + "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(padded))
+
+
+def _url(value: str) -> AnyUrl:
+    return _ANY_URL.validate_python(value)
+
+
+def test_api_key_oauth_issues_stateless_encrypted_claim_tokens():
+    async def run():
+        api_key = "bp_secret_test_key"
+        validation_calls = []
+
+        def validate(key: str) -> bool:
+            validation_calls.append(key)
+            return key == api_key
+
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=validate,
+        )
+        client = OAuthClientInformationFull(
+            client_id="client-1",
+            client_name="Claude Desktop",
+            redirect_uris=[_url("http://localhost/callback")],
+        )
+        await provider.register_client(client)
+
+        auth_url = await provider.authorize(
+            client,
+            AuthorizationParams(
+                state="state-1",
+                scopes=[],
+                code_challenge="challenge-1",
+                redirect_uri=_url("http://localhost/callback"),
+                redirect_uri_provided_explicitly=True,
+            ),
+        )
+        txn_id = parse_qs(urlparse(auth_url).query)["txn_id"][0]
+        txn = provider._load_container_token(txn_id, expected_use="auth-txn")
+        assert txn is not None
+        assert "api_key" not in txn
+
+        code = provider._issue_container_token(
+            container_use="auth-code",
+            expires_in=300,
+            claims={**txn, "encrypted_api_key": provider._encrypt_api_key(api_key)},
+        )
+        auth_code = await provider.load_authorization_code(client, code)
+        assert auth_code is not None
+
+        token = await provider.exchange_authorization_code(client, auth_code)
+        payload = _decode_jwt_payload(token.access_token)
+        assert payload["jti"]
+        assert payload["bauplan_api_key_enc"]
+        assert api_key not in json.dumps(payload)
+
+        access_token = await provider.load_access_token(token.access_token)
+        assert access_token is not None
+        assert access_token.claims[BAUPLAN_API_KEY_CLAIM] == api_key
+        assert validation_calls == []
+
+        assert await provider.load_authorization_code(client, code) is not None
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_registration_is_stateless_across_provider_instances():
+    async def run():
+        config = OAuthConfig(
+            base_url="https://mcp.example.com",
+            secret="x" * 32,
+        )
+        provider = APIKeyOAuthProvider(config=config, validate_api_key=lambda _: True)
+        client = OAuthClientInformationFull(
+            client_id="original-client-id",
+            client_secret="original-client-secret",
+            token_endpoint_auth_method="client_secret_post",
+            client_name="Claude Desktop",
+            redirect_uris=[_url("http://localhost/callback")],
+        )
+
+        await provider.register_client(client)
+
+        assert client.client_id is not None
+        assert client.client_id != "original-client-id"
+        assert client.client_secret is None
+        assert client.token_endpoint_auth_method == "none"
+
+        fresh_provider = APIKeyOAuthProvider(config=config, validate_api_key=lambda _: True)
+        decoded_client = await fresh_provider.get_client(client.client_id)
+
+        assert decoded_client is not None
+        assert decoded_client.client_id == client.client_id
+        assert decoded_client.client_secret is None
+        assert decoded_client.token_endpoint_auth_method == "none"
+        assert decoded_client.client_name == "Claude Desktop"
+        assert [str(uri) for uri in decoded_client.redirect_uris or []] == ["http://localhost/callback"]
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_rejects_mismatched_resource():
+    async def run():
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda _: True,
+        )
+        client = OAuthClientInformationFull(
+            client_id="client-1",
+            client_name="Claude Desktop",
+            redirect_uris=[_url("http://localhost/callback")],
+        )
+
+        with pytest.raises(AuthorizeError, match="resource"):
+            await provider.authorize(
+                client,
+                AuthorizationParams(
+                    state="state-1",
+                    scopes=[],
+                    code_challenge="challenge-1",
+                    redirect_uri=_url("http://localhost/callback"),
+                    redirect_uri_provided_explicitly=True,
+                    resource="https://other.example.com/mcp",
+                ),
+            )
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_loads_access_token_without_revalidating_key():
+    async def run():
+        api_key = "bp_secret_test_key"
+        validation_calls = 0
+
+        def validate(_: str) -> bool:
+            nonlocal validation_calls
+            validation_calls += 1
+            return False
+
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=validate,
+        )
+        token = await provider._issue_tokens(
+            encrypted_api_key=provider._encrypt_api_key(api_key),
+            client_id="client-1",
+            scopes=[],
+        )
+        access_token = await provider.load_access_token(token.access_token)
+
+        assert access_token is not None
+        assert access_token.claims[BAUPLAN_API_KEY_CLAIM] == api_key
+        assert validation_calls == 0
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_rejects_non_access_token_on_access_load():
+    async def run():
+        api_key = "bp_secret_test_key"
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda _: True,
+        )
+        code = provider._issue_container_token(
+            container_use="auth-code",
+            expires_in=300,
+            claims={
+                "client_id": "client-1",
+                "encrypted_api_key": provider._encrypt_api_key(api_key),
+            },
+        )
+
+        assert await provider.load_access_token(code) is None
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_returns_none_for_non_ascii_encrypted_claim():
+    async def run():
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda _: True,
+        )
+        payload = {
+            "iss": "https://mcp.example.com",
+            "aud": "https://mcp.example.com/mcp",
+            "client_id": "client-1",
+            "scope": "",
+            "exp": 9_999_999_999,
+            "iat": 1,
+            "jti": "jti-1",
+            "token_use": "access",
+            "bauplan_api_key_enc": "é",
+        }
+        token = provider._jwt.encode({"alg": "HS256", "typ": "JWT"}, payload, provider._signing_key).decode(
+            "utf-8"
+        )
+
+        assert await provider.load_access_token(token) is None
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_refresh_token_is_stateless_container():
+    async def run():
+        api_key = "bp_secret_test_key"
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda _: True,
+        )
+        token = await provider._issue_tokens(
+            encrypted_api_key=provider._encrypt_api_key(api_key),
+            client_id="client-1",
+            scopes=[],
+        )
+        client = OAuthClientInformationFull(
+            client_id="client-1", redirect_uris=[_url("http://localhost/callback")]
+        )
+        assert token.refresh_token is not None
+
+        refresh_token = await provider.load_refresh_token(client, token.refresh_token)
+        assert refresh_token is not None
+
+        new_token = await provider.exchange_refresh_token(client, refresh_token, scopes=[])
+        assert new_token.refresh_token != token.refresh_token
+        assert await provider.load_refresh_token(client, token.refresh_token) is not None
+
+        access_token = await provider.load_access_token(new_token.access_token)
+        assert access_token is not None
+        assert access_token.claims[BAUPLAN_API_KEY_CLAIM] == api_key
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_refresh_exchange_wraps_invalid_token_as_token_error():
+    async def run():
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda _: True,
+        )
+        client = OAuthClientInformationFull(
+            client_id="client-1", redirect_uris=[_url("http://localhost/callback")]
+        )
+
+        with pytest.raises(TokenError, match="Refresh token invalid"):
+            await provider.exchange_refresh_token(
+                client,
+                RefreshToken(token="not-a-jwt", client_id="client-1", scopes=[]),
+                scopes=[],
+            )
+
+    asyncio.run(run())

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,0 +1,36 @@
+import pytest
+
+from mcp_bauplan.auth.config import get_auth_mode, load_oauth_config
+
+
+def test_auth_mode_defaults_to_none(monkeypatch):
+    monkeypatch.delenv("MCP_AUTH_MODE", raising=False)
+
+    assert get_auth_mode() == "none"
+
+
+def test_unknown_auth_mode_fails(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_MODE", "unknown")
+
+    with pytest.raises(ValueError, match="MCP_AUTH_MODE"):
+        get_auth_mode()
+
+
+def test_oauth_config_requires_strong_secret(monkeypatch):
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://mcp.example.com/")
+    monkeypatch.setenv("MCP_OAUTH_SECRET", "short")
+
+    with pytest.raises(ValueError, match="MCP_OAUTH_SECRET"):
+        load_oauth_config()
+
+
+def test_oauth_config_normalizes_base_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://mcp.example.com/")
+    monkeypatch.setenv("MCP_OAUTH_SECRET", "x" * 32)
+    monkeypatch.setenv("MCP_OAUTH_CLIENT_REGISTRATION_TTL_SECONDS", "86400")
+
+    config = load_oauth_config()
+
+    assert config.base_url == "https://mcp.example.com"
+    assert config.secret == "x" * 32
+    assert config.client_registration_ttl_seconds == 86400

--- a/tests/test_create_client.py
+++ b/tests/test_create_client.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+import mcp_bauplan.tools.create_client as create_client
+from mcp_bauplan.auth.config import BAUPLAN_API_KEY_CLAIM
+
+
+class FakeBauplanClient:
+    api_keys: ClassVar[list[str | None]] = []
+
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+        self.api_keys.append(api_key)
+
+
+def test_get_bauplan_client_uses_bauplan_header(monkeypatch):
+    FakeBauplanClient.api_keys = []
+    monkeypatch.setattr(create_client.bauplan, "Client", FakeBauplanClient)
+    monkeypatch.setattr(
+        create_client,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={"Bauplan": "header-key", "Authorization": "Bearer auth-key"}),
+    )
+
+    create_client.get_bauplan_client()
+
+    assert FakeBauplanClient.api_keys[-1] == "header-key"
+
+
+def test_get_bauplan_client_uses_oauth_claim_in_oauth_mode(monkeypatch):
+    FakeBauplanClient.api_keys = []
+    monkeypatch.setenv("MCP_AUTH_MODE", "api-key-oauth")
+    monkeypatch.setattr(create_client.bauplan, "Client", FakeBauplanClient)
+    monkeypatch.setattr(
+        create_client,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={"Authorization": "Bearer oauth-jwt"}),
+    )
+    monkeypatch.setattr(
+        create_client,
+        "get_access_token",
+        lambda: SimpleNamespace(token="oauth-token", claims={BAUPLAN_API_KEY_CLAIM: "oauth-key"}),
+    )
+
+    create_client.get_bauplan_client()
+
+    assert FakeBauplanClient.api_keys[-1] == "oauth-key"
+
+
+def test_get_bauplan_client_does_not_use_authorization_header_in_oauth_mode(monkeypatch):
+    FakeBauplanClient.api_keys = []
+    monkeypatch.setenv("MCP_AUTH_MODE", "api-key-oauth")
+    monkeypatch.setattr(create_client.bauplan, "Client", FakeBauplanClient)
+    monkeypatch.setattr(
+        create_client,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={"Authorization": "Bearer oauth-jwt"}),
+    )
+    monkeypatch.setattr(
+        create_client,
+        "get_access_token",
+        lambda: SimpleNamespace(token="oauth-jwt", claims={}),
+    )
+
+    with pytest.raises(RuntimeError, match="User is not authenticated"):
+        create_client.get_bauplan_client()
+
+    assert FakeBauplanClient.api_keys == []
+
+
+def test_get_bauplan_client_reports_unauthenticated_when_oauth_context_is_missing(monkeypatch):
+    FakeBauplanClient.api_keys = []
+    monkeypatch.setenv("MCP_AUTH_MODE", "api-key-oauth")
+    monkeypatch.setattr(create_client.bauplan, "Client", FakeBauplanClient)
+    monkeypatch.setattr(
+        create_client,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={"Authorization": "Bearer oauth-jwt"}),
+    )
+    monkeypatch.setattr(
+        create_client,
+        "get_access_token",
+        lambda: (_ for _ in ()).throw(RuntimeError("missing auth context")),
+    )
+
+    with pytest.raises(RuntimeError, match="User is not authenticated"):
+        create_client.get_bauplan_client()
+
+    assert FakeBauplanClient.api_keys == []
+
+
+def test_get_bauplan_client_uses_default_credentials_for_http_without_headers(monkeypatch):
+    FakeBauplanClient.api_keys = []
+    monkeypatch.delenv("MCP_AUTH_MODE", raising=False)
+    monkeypatch.setattr(create_client.bauplan, "Client", FakeBauplanClient)
+    monkeypatch.setattr(
+        create_client,
+        "get_http_request",
+        lambda: SimpleNamespace(headers={}),
+    )
+    monkeypatch.setattr(create_client, "get_access_token", lambda: None)
+
+    create_client.get_bauplan_client()
+
+    assert FakeBauplanClient.api_keys[-1] is None
+
+
+def test_get_bauplan_client_uses_default_credentials_outside_http_context(monkeypatch):
+    FakeBauplanClient.api_keys = []
+    monkeypatch.setattr(create_client.bauplan, "Client", FakeBauplanClient)
+    monkeypatch.setattr(
+        create_client, "get_http_request", lambda: (_ for _ in ()).throw(RuntimeError("no http"))
+    )
+
+    create_client.get_bauplan_client()
+
+    assert FakeBauplanClient.api_keys[-1] is None

--- a/uv.lock
+++ b/uv.lock
@@ -619,6 +619,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -821,7 +830,9 @@ name = "mcp-bauplan"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "authlib" },
     { name = "bauplan" },
+    { name = "cryptography" },
     { name = "fastmcp" },
     { name = "pydantic" },
     { name = "uvicorn", extra = ["standard"] },
@@ -843,12 +854,15 @@ otel = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "watchdog", extra = ["watchmedo"] },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", specifier = ">=1.6.0" },
     { name = "bauplan", specifier = ">=0.0.3a431" },
+    { name = "cryptography", specifier = ">=46.0.0" },
     { name = "fastmcp", specifier = "~=2.14.5" },
     { name = "opentelemetry-distro", marker = "extra == 'otel'", specifier = "==0.60b1" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = "==1.39.1" },
@@ -866,7 +880,10 @@ requires-dist = [
 provides-extras = ["otel"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "watchdog", extras = ["watchmedo"], specifier = "~=6.0.0" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.0" },
+    { name = "watchdog", extras = ["watchmedo"], specifier = "~=6.0.0" },
+]
 
 [[package]]
 name = "mdurl"
@@ -1236,6 +1253,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1510,6 +1536,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an API-key-backed OAuth mode for OAuth-only MCP clients such as Claude Desktop, without storing user API keys server-side.

The Bauplan API key is collected during the OAuth authorization flow, encrypted into stateless tokens, and exposed only during request handling to create the Bauplan client.
Existing local/stdio and header-based HTTP auth behavior remains supported outside OAuth mode.