### PR TITLE
docs: fix docstring inconsistencies in 4 tools

### DIFF
--- a/mcp_bauplan/tools/get_namespaces.py
+++ b/mcp_bauplan/tools/get_namespaces.py
@@ -35,7 +35,7 @@ def register_get_namespaces_tool(mcp: FastMCP) -> None:
             ref: branch or commit hash to get namespaces from. Can be either a hash that starts with "@" and
                 has 64 additional characters or a branch name, that is a mnemonic reference to the last commit that follows the "username.name" format.
             namespace: Optional filter for namespace names (substring match)
-            limit: Optional maximum number of namespaces to return (default: 50)
+            limit: Optional maximum number of namespaces to return (default: 10)
 
         Returns:
             NamespacesOut: Object containing list of namespaces and total count

--- a/mcp_bauplan/tools/get_tags.py
+++ b/mcp_bauplan/tools/get_tags.py
@@ -27,8 +27,8 @@ def register_get_tags_tool(mcp: FastMCP) -> None:
         bauplan_client: bauplan.Client = Depends(get_bauplan_client),
     ) -> TagsOut:
         """
-        Retrieve tags for a specified branch in the user's Bauplan data catalog as a list, using a branch name with optional filter_by_name and limit (integer) to reduce response size.
-        Get the tags of a branch using optional filters.
+        Retrieve tags from the user's Bauplan data catalog as a list, with optional filter_by_name and limit (integer) to reduce response size.
+        Get the tags using optional filters.
 
         Args:
             filter_by_name: Optional filter for tag names (substring match)

--- a/mcp_bauplan/tools/has_tag.py
+++ b/mcp_bauplan/tools/has_tag.py
@@ -30,7 +30,7 @@ def register_has_tag_tool(mcp: FastMCP) -> None:
         bauplan_client: bauplan.Client = Depends(get_bauplan_client),
     ) -> TagExists:
         """
-        Check if a specified tag exists in a given branch of the user's Bauplan data catalog using a tag name and branch name.
+        Check if a specified tag exists in the user's Bauplan data catalog using a tag name.
 
         Args:
             tag: Name of the tag to check for existence.

--- a/mcp_bauplan/tools/run_query.py
+++ b/mcp_bauplan/tools/run_query.py
@@ -78,7 +78,7 @@ def register_run_query_tool(mcp: FastMCP) -> None:
         bauplan_client: bauplan.Client = Depends(get_bauplan_client),
     ) -> QueryOut:
         """
-        Execute a SQL SELECT query on the user's Bauplan data catalog, returning results as a DataFrame using a query, optional ref, and optional namespace.
+        Execute a SQL SELECT query on the user's Bauplan data catalog, returning results as a QueryOut object using a query, optional ref, and optional namespace.
         Executes a SQL query against the user's Bauplan data lake.
 
         Args:


### PR DESCRIPTION
Fixes docstring inconsistencies in 4 tools, extending patterns from #12 and #13. See companion issue: https://github.com/BauplanLabs/bauplan-mcp-server/issues/51

- `get_tags`, `has_tag`: remove non-existent `branch` parameter references (extension of #12)
- `get_namespaces`: align documented default with code (10, not 50)
- `run_query`: describe actual return type (`QueryOut`, not `DataFrame`) (extension of #13)
