### PR TITLE
fix(oauth) fix callback redirect status

### DIFF
--- a/mcp_bauplan/auth/api_key_oauth.py
+++ b/mcp_bauplan/auth/api_key_oauth.py
@@ -204,7 +204,7 @@ class APIKeyOAuthProvider(OAuthProvider):
         location = construct_redirect_uri(
             str(txn["redirect_uri"]), code=code, state=str(txn.get("state") or "")
         )
-        return RedirectResponse(location, status_code=303, headers=_NO_STORE_HEADERS)
+        return RedirectResponse(location, status_code=302, headers=_NO_STORE_HEADERS)
 
     async def _call_validate_api_key(self, api_key: str) -> bool:
         result = self._validate_api_key(api_key)

--- a/tests/test_api_key_oauth.py
+++ b/tests/test_api_key_oauth.py
@@ -152,6 +152,66 @@ def test_api_key_oauth_rejects_mismatched_resource():
     asyncio.run(run())
 
 
+def test_api_key_oauth_submit_redirects_with_found_status():
+    async def run():
+        api_key = "bp_secret_test_key"
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda key: key == api_key,
+        )
+        txn_id = provider._issue_container_token(
+            container_use="auth-txn",
+            expires_in=300,
+            claims={
+                "client_id": "client-1",
+                "client_name": "Claude",
+                "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+                "redirect_uri_provided_explicitly": True,
+                "state": "state-1",
+                "code_challenge": "challenge-1",
+                "scopes": [],
+                "resource": "https://mcp.example.com/mcp",
+            },
+        )
+
+        body = f"txn_id={txn_id}&api_key={api_key}".encode()
+        from collections.abc import MutableMapping
+        from typing import Any
+
+        from starlette.requests import Request
+
+        async def receive() -> MutableMapping[str, Any]:
+            return {
+                "type": "http.request",
+                "body": body,
+                "more_body": False,
+            }
+
+        request: Request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/bauplan-api-key",
+                "headers": [
+                    (b"content-type", b"application/x-www-form-urlencoded"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            },
+            receive=receive,
+        )
+
+        response = await provider._handle_submit(request)
+
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("https://claude.ai/api/mcp/auth_callback?code=")
+        assert "state=state-1" in response.headers["location"]
+
+    asyncio.run(run())
+
+
 def test_api_key_oauth_loads_access_token_without_revalidating_key():
     async def run():
         api_key = "bp_secret_test_key"


### PR DESCRIPTION
Return 302 Found after the Bauplan API key authorization form is submitted.

OAuth authorization responses are expected to redirect the user agent back to the registered callback URL with a Location header. 
Using 302 is more compatible with Claude's OAuth webview flow than 303, while preserving the same callback URL, authorization code, and state handling.