### PR TITLE
fix(oauth) claude completion flow

### DIFF
--- a/mcp_bauplan/auth/api_key_oauth.py
+++ b/mcp_bauplan/auth/api_key_oauth.py
@@ -6,7 +6,8 @@ import logging
 import secrets
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, cast
 
 from authlib.jose import JsonWebToken
 from authlib.jose.errors import JoseError
@@ -24,7 +25,7 @@ from mcp.server.auth.provider import (
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import AnyUrl, TypeAdapter, ValidationError
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, RedirectResponse, Response
+from starlette.responses import HTMLResponse, Response
 from starlette.routing import Route
 
 from .config import BAUPLAN_API_KEY_CLAIM, OAuthConfig
@@ -38,7 +39,7 @@ _CLIENT_REGISTRATION_USE = "client-registration"
 
 _SIGNING_SALT = "bauplan-mcp-oauth-signing"
 _STORAGE_SALT = "bauplan-mcp-api-key-storage"
-_AUTH_CODE_TTL_SECONDS = 60
+_AUTH_CODE_TTL_SECONDS = 5 * 60
 _TXN_TTL_SECONDS = 15 * 60
 _PUBLIC_CLIENT_AUTH_METHOD = "none"
 
@@ -54,7 +55,14 @@ _HTML_SECURITY_HEADERS = {
     "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'",
 }
 
-ValidateApiKey = Callable[[str], bool | Awaitable[bool]]
+
+@dataclass(frozen=True)
+class BauplanUserInfo:
+    username: str | None
+    full_name: str | None
+
+
+ValidateApiKey = Callable[[str], BauplanUserInfo | None | Awaitable[BauplanUserInfo | None]]
 
 
 class APIKeyOAuthProvider(OAuthProvider):
@@ -189,7 +197,8 @@ class APIKeyOAuthProvider(OAuthProvider):
         if not api_key:
             return _html_response("A Bauplan API key is required.", 400)
 
-        if not await self._call_validate_api_key(api_key):
+        user_info = await self._call_validate_api_key(api_key)
+        if user_info is None:
             logger.info("Rejected Bauplan API key during OAuth authorization")
             return _html_response("The provided Bauplan API key could not be validated.", 401)
 
@@ -204,13 +213,35 @@ class APIKeyOAuthProvider(OAuthProvider):
         location = construct_redirect_uri(
             str(txn["redirect_uri"]), code=code, state=str(txn.get("state") or "")
         )
-        return RedirectResponse(location, status_code=302, headers=_NO_STORE_HEADERS)
+        escaped_location = html.escape(location, quote=True)
+        escaped_username = html.escape(user_info.username) if user_info.username else None
+        escaped_full_name = html.escape(user_info.full_name) if user_info.full_name else None
+        user_lines = ""
+        if escaped_username:
+            user_lines += f"  <p>Username: <strong>{escaped_username}</strong></p>\n"
+        if escaped_full_name:
+            user_lines += f"  <p>Name: <strong>{escaped_full_name}</strong></p>\n"
+        page = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bauplan MCP Authorization Complete</title>
+</head>
+<body>
+  <h1>Authorization complete</h1>
+  <p>Your Bauplan API key was validated.</p>
+{user_lines}  <p>Continue to complete the Claude connection.</p>
+  <p><a href="{escaped_location}" role="button">Return to Claude</a></p>
+</body>
+</html>"""
+        return HTMLResponse(page, headers=_HTML_SECURITY_HEADERS)
 
-    async def _call_validate_api_key(self, api_key: str) -> bool:
+    async def _call_validate_api_key(self, api_key: str) -> BauplanUserInfo | None:
         result = self._validate_api_key(api_key)
         if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
             result = await result
-        return bool(result)
+        return cast(BauplanUserInfo | None, result)
 
     async def load_authorization_code(
         self,
@@ -402,15 +433,19 @@ class APIKeyOAuthProvider(OAuthProvider):
         return dict(payload)
 
 
-async def validate_bauplan_api_key(api_key: str) -> bool:
+async def validate_bauplan_api_key(api_key: str) -> BauplanUserInfo | None:
     """Validate a Bauplan API key without leaking exception details to clients."""
     try:
         import bauplan
 
-        await asyncio.to_thread(bauplan.Client(api_key=api_key).info)
+        info = await asyncio.to_thread(bauplan.Client(api_key=api_key).info)
+        user = info.user
     except Exception:
-        return False
-    return True
+        return None
+    return BauplanUserInfo(
+        username=getattr(user, "username", None),
+        full_name=getattr(user, "full_name", None),
+    )
 
 
 def create_api_key_oauth_provider(config: OAuthConfig) -> APIKeyOAuthProvider:

--- a/tests/test_api_key_oauth.py
+++ b/tests/test_api_key_oauth.py
@@ -8,7 +8,7 @@ from mcp.server.auth.provider import AuthorizationParams, AuthorizeError, Refres
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl, TypeAdapter
 
-from mcp_bauplan.auth.api_key_oauth import APIKeyOAuthProvider
+from mcp_bauplan.auth.api_key_oauth import APIKeyOAuthProvider, BauplanUserInfo
 from mcp_bauplan.auth.config import BAUPLAN_API_KEY_CLAIM, OAuthConfig
 
 _ANY_URL = TypeAdapter(AnyUrl)
@@ -24,14 +24,18 @@ def _url(value: str) -> AnyUrl:
     return _ANY_URL.validate_python(value)
 
 
+def _user_info() -> BauplanUserInfo:
+    return BauplanUserInfo(username="test-user", full_name="Test User")
+
+
 def test_api_key_oauth_issues_stateless_encrypted_claim_tokens():
     async def run():
         api_key = "bp_secret_test_key"
         validation_calls = []
 
-        def validate(key: str) -> bool:
+        def validate(key: str) -> BauplanUserInfo | None:
             validation_calls.append(key)
-            return key == api_key
+            return _user_info() if key == api_key else None
 
         provider = APIKeyOAuthProvider(
             config=OAuthConfig(
@@ -92,7 +96,7 @@ def test_api_key_oauth_registration_is_stateless_across_provider_instances():
             base_url="https://mcp.example.com",
             secret="x" * 32,
         )
-        provider = APIKeyOAuthProvider(config=config, validate_api_key=lambda _: True)
+        provider = APIKeyOAuthProvider(config=config, validate_api_key=lambda _: _user_info())
         client = OAuthClientInformationFull(
             client_id="original-client-id",
             client_secret="original-client-secret",
@@ -108,7 +112,7 @@ def test_api_key_oauth_registration_is_stateless_across_provider_instances():
         assert client.client_secret is None
         assert client.token_endpoint_auth_method == "none"
 
-        fresh_provider = APIKeyOAuthProvider(config=config, validate_api_key=lambda _: True)
+        fresh_provider = APIKeyOAuthProvider(config=config, validate_api_key=lambda _: _user_info())
         decoded_client = await fresh_provider.get_client(client.client_id)
 
         assert decoded_client is not None
@@ -128,7 +132,7 @@ def test_api_key_oauth_rejects_mismatched_resource():
                 base_url="https://mcp.example.com",
                 secret="x" * 32,
             ),
-            validate_api_key=lambda _: True,
+            validate_api_key=lambda _: _user_info(),
         )
         client = OAuthClientInformationFull(
             client_id="client-1",
@@ -152,7 +156,7 @@ def test_api_key_oauth_rejects_mismatched_resource():
     asyncio.run(run())
 
 
-def test_api_key_oauth_submit_redirects_with_found_status():
+def test_api_key_oauth_submit_returns_completion_page():
     async def run():
         api_key = "bp_secret_test_key"
         provider = APIKeyOAuthProvider(
@@ -160,7 +164,7 @@ def test_api_key_oauth_submit_redirects_with_found_status():
                 base_url="https://mcp.example.com",
                 secret="x" * 32,
             ),
-            validate_api_key=lambda key: key == api_key,
+            validate_api_key=lambda key: _user_info() if key == api_key else None,
         )
         txn_id = provider._issue_container_token(
             container_use="auth-txn",
@@ -205,9 +209,142 @@ def test_api_key_oauth_submit_redirects_with_found_status():
 
         response = await provider._handle_submit(request)
 
-        assert response.status_code == 302
-        assert response.headers["location"].startswith("https://claude.ai/api/mcp/auth_callback?code=")
-        assert "state=state-1" in response.headers["location"]
+        body = bytes(response.body).decode()
+        assert response.status_code == 200
+        assert "Return to Claude" in body
+        assert "Your Bauplan API key was validated." in body
+        assert "test-user" in body
+        assert "Test User" in body
+        assert "https://claude.ai/api/mcp/auth_callback?code=" in body
+        assert "state=state-1" in body
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_submit_issues_code_with_human_click_ttl(monkeypatch):
+    async def run():
+        api_key = "bp_secret_test_key"
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda key: _user_info() if key == api_key else None,
+        )
+        txn_id = provider._issue_container_token(
+            container_use="auth-txn",
+            expires_in=300,
+            claims={
+                "client_id": "client-1",
+                "client_name": "Claude",
+                "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+                "redirect_uri_provided_explicitly": True,
+                "state": "state-1",
+                "code_challenge": "challenge-1",
+                "scopes": [],
+                "resource": "https://mcp.example.com/mcp",
+            },
+        )
+
+        monkeypatch.setattr("mcp_bauplan.auth.api_key_oauth.time.time", lambda: 1_000)
+
+        body = f"txn_id={txn_id}&api_key={api_key}".encode()
+        from collections.abc import MutableMapping
+        from typing import Any
+
+        from starlette.requests import Request
+
+        async def receive() -> MutableMapping[str, Any]:
+            return {
+                "type": "http.request",
+                "body": body,
+                "more_body": False,
+            }
+
+        request: Request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/bauplan-api-key",
+                "headers": [
+                    (b"content-type", b"application/x-www-form-urlencoded"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            },
+            receive=receive,
+        )
+
+        response = await provider._handle_submit(request)
+        callback_url = urlparse(bytes(response.body).decode().split('href="', 1)[1].split('"', 1)[0])
+        code = parse_qs(callback_url.query)["code"][0]
+        payload = _decode_jwt_payload(code)
+
+        assert payload["exp"] - payload["iat"] == 5 * 60
+
+    asyncio.run(run())
+
+
+def test_api_key_oauth_submit_escapes_user_info():
+    async def run():
+        api_key = "bp_secret_test_key"
+        provider = APIKeyOAuthProvider(
+            config=OAuthConfig(
+                base_url="https://mcp.example.com",
+                secret="x" * 32,
+            ),
+            validate_api_key=lambda _: BauplanUserInfo(
+                username='<script>alert("x")</script>',
+                full_name="Alice & Bob <img src=x onerror=alert(1)>",
+            ),
+        )
+        txn_id = provider._issue_container_token(
+            container_use="auth-txn",
+            expires_in=300,
+            claims={
+                "client_id": "client-1",
+                "client_name": "Claude",
+                "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+                "redirect_uri_provided_explicitly": True,
+                "state": "state-1",
+                "code_challenge": "challenge-1",
+                "scopes": [],
+                "resource": "https://mcp.example.com/mcp",
+            },
+        )
+
+        body = f"txn_id={txn_id}&api_key={api_key}".encode()
+        from collections.abc import MutableMapping
+        from typing import Any
+
+        from starlette.requests import Request
+
+        async def receive() -> MutableMapping[str, Any]:
+            return {
+                "type": "http.request",
+                "body": body,
+                "more_body": False,
+            }
+
+        request: Request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/bauplan-api-key",
+                "headers": [
+                    (b"content-type", b"application/x-www-form-urlencoded"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            },
+            receive=receive,
+        )
+
+        response = await provider._handle_submit(request)
+        response_body = bytes(response.body).decode()
+
+        assert "<script>" not in response_body
+        assert "<img" not in response_body
+        assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in response_body
+        assert "Alice &amp; Bob &lt;img src=x onerror=alert(1)&gt;" in response_body
 
     asyncio.run(run())
 
@@ -217,10 +354,10 @@ def test_api_key_oauth_loads_access_token_without_revalidating_key():
         api_key = "bp_secret_test_key"
         validation_calls = 0
 
-        def validate(_: str) -> bool:
+        def validate(_: str) -> BauplanUserInfo | None:
             nonlocal validation_calls
             validation_calls += 1
-            return False
+            return None
 
         provider = APIKeyOAuthProvider(
             config=OAuthConfig(
@@ -251,7 +388,7 @@ def test_api_key_oauth_rejects_non_access_token_on_access_load():
                 base_url="https://mcp.example.com",
                 secret="x" * 32,
             ),
-            validate_api_key=lambda _: True,
+            validate_api_key=lambda _: _user_info(),
         )
         code = provider._issue_container_token(
             container_use="auth-code",
@@ -274,7 +411,7 @@ def test_api_key_oauth_returns_none_for_non_ascii_encrypted_claim():
                 base_url="https://mcp.example.com",
                 secret="x" * 32,
             ),
-            validate_api_key=lambda _: True,
+            validate_api_key=lambda _: _user_info(),
         )
         payload = {
             "iss": "https://mcp.example.com",
@@ -304,7 +441,7 @@ def test_api_key_oauth_refresh_token_is_stateless_container():
                 base_url="https://mcp.example.com",
                 secret="x" * 32,
             ),
-            validate_api_key=lambda _: True,
+            validate_api_key=lambda _: _user_info(),
         )
         token = await provider._issue_tokens(
             encrypted_api_key=provider._encrypt_api_key(api_key),
@@ -337,7 +474,7 @@ def test_api_key_oauth_refresh_exchange_wraps_invalid_token_as_token_error():
                 base_url="https://mcp.example.com",
                 secret="x" * 32,
             ),
-            validate_api_key=lambda _: True,
+            validate_api_key=lambda _: _user_info(),
         )
         client = OAuthClientInformationFull(
             client_id="client-1", redirect_uris=[_url("http://localhost/callback")]


### PR DESCRIPTION
Replace the automatic OAuth callback redirect after API key validation with a completion page that asks the user to return to Claude explicitly.  
The page confirms that the Bauplan API key was validated, displays escaped Bauplan user information from client.info(), and links to Claude's OAuth callback with the authorization code and state.
The auth code TTL is extended to 5 minutes to account for the manual click step, while keeping the flow stateless and avoiding server-side credential storage.