### PR TITLE
build(docker): install python with uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,48 @@
-ARG UV_VERSION="0.10.5"
-ARG PYTHON_VERSION="3.12"
+ARG CI_BUILD_VERSION="3.13"
+ARG UV_VERSION="0.11.16"
+
+
+#
+# Stage: uv
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 
 
 #
 # Stage: builder
-# Uses the combined uv+python image for faster builds
-FROM ghcr.io/astral-sh/uv:${UV_VERSION}-python${PYTHON_VERSION}-trixie-slim AS builder
+FROM debian:trixie-slim AS builder
+
+COPY --from=uv /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv
+ENV UV_PYTHON_INSTALL_DIR=/usr/local/uv/python
 
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml uv.lock ./
 
+ARG CI_BUILD_VERSION
 RUN --mount=type=cache,target=/root/.cache/uv \
-  uv sync --locked --no-install-project --no-dev --extra otel
+  uv python install ${CI_BUILD_VERSION}
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+  uv sync --locked --python ${CI_BUILD_VERSION} --no-install-project --no-dev --extra otel
 
 COPY mcp_bauplan/ mcp_bauplan/
 COPY main.py README.md ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-  uv sync --locked --no-dev --extra otel
+  uv sync --locked --python ${CI_BUILD_VERSION} --no-dev --extra otel
 
 
 #
 # Stage: final
-FROM python:${PYTHON_VERSION}-slim-trixie AS final
+FROM debian:trixie-slim AS final
 
 ENV TZ=UTC
 ENV LC_ALL=C.UTF-8
@@ -41,14 +57,16 @@ ENV TRACELOOP_TRACE_CONTENT=false
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends curl \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --create-home bauplan
 
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV=/app/.venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 USER bauplan
 
+COPY --from=builder /usr/local/uv/python /usr/local/uv/python
 COPY --from=builder --chown=bauplan:bauplan /app/.venv /app/.venv
 COPY --chown=bauplan:bauplan main.py entrypoint.sh ./
 COPY --chown=bauplan:bauplan mcp_bauplan/ mcp_bauplan/

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-uv = "0.10.5"
+uv = "0.11.16"
 ruff = "0.15.2"
 ty = "0.0.18"
 pre-commit = "latest"
@@ -7,6 +7,9 @@ pre-commit = "latest"
 
 [settings]
 experimental = true
+
+[env]
+UV_PYTHON = "3.13"
 
 [tasks.lint]
 description = "Run ruff linter"
@@ -22,11 +25,20 @@ run = "ruff format --check ."
 
 [tasks.typecheck]
 description = "Run ty type checker"
-run = "ty check ."
+run = "uv run ty check ."
+
+[tasks.test]
+description = "Run pytest"
+run = "uv run pytest -q"
 
 [tasks.check]
-description = "Run all checks (lint, format, typecheck)"
-depends = ["lint", "format:check", "typecheck"]
+description = "Run all checks (lint, format, typecheck, test)"
+run = """
+ruff check .
+ruff format --check .
+uv run ty check .
+uv run pytest -q
+"""
 
 [tasks.dev]
 description = "Start MCP HTTP server with auto-reload on code changes"


### PR DESCRIPTION
Use the CI-provided Python version during the Docker build so the image runtime matches the version selected by the pipeline.
Copy the uv-managed Python install and resolved virtualenv into the final slim image.